### PR TITLE
Made two of the regular expressions compatible with PHP 5.5+

### DIFF
--- a/src/Frozennode/XssInput/Security.php
+++ b/src/Frozennode/XssInput/Security.php
@@ -422,8 +422,8 @@ class Security {
 			return $str;
 		}
 		$str = html_entity_decode($str, ENT_COMPAT, $charset);
-		$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str);
-		return preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str);
+		$str = preg_replace_callback('~&#x(0*[0-9a-f]{2,5})~i', create_function('$matches', 'return chr(hexdec($matches[1]));'), $str);
+		return preg_replace_callback('~&#([0-9]{2,4})~', create_function('$matches', 'return chr($matches[1]);'), $str);
 	}//entity_decode
 	/**
 	 * Filter Attributes


### PR DESCRIPTION
The /e modifier was deprecated in PHP 5.5 and it is recommended to use preg_replace_callback instead. I found two (hopefully the only two) instances of the /e modifier being used in the security class and replaced them with preg_replace_callback() versions. This change will continue to work in PHP 5.3 as there is nothing new about how preg_replace_callback() is being used.
